### PR TITLE
Only add snow to blocks where it is snowing

### DIFF
--- a/src/main/java/com/github/draylar/snowdrift/logic/SnowIncrementer.java
+++ b/src/main/java/com/github/draylar/snowdrift/logic/SnowIncrementer.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class SnowIncrementer {
+    private static final float MAX_SNOW_TEMP = 0.15f;
 
     public void tickSnow(ServerWorld world, List<Chunk> loadedChunks) {
         loadedChunks.forEach(chunk -> {
@@ -34,6 +35,10 @@ public class SnowIncrementer {
     private void tryIncrementSnowAt(ServerWorld world, BlockPos basePos) {
         BlockPos topPos = world.getTopPosition(Heightmap.Type.MOTION_BLOCKING, basePos);
         BlockState topState = world.getBlockState(topPos);
+
+        if(world.getBiomeAccess().getBiome(topPos).getTemperature(topPos) > MAX_SNOW_TEMP) {
+            return;
+        }
 
         if(getSnowLevelAt(world, topPos) >= Snowdrift.CONFIG.maxLayers) {
             return;


### PR DESCRIPTION
@Draylar This fixes an issue that some people on CurseForge were posting about where snow piles show up everywhere, even where it is raining.

This checks the temperature of the block to make sure that it is snowing (and not raining) at that location. I got the value `0.15f` from the Minecraft `Biome.canSetSnow` and `Biome.canSetIce` methods. I tested it in various biomes and it seems to be working.

This is also my first time doing any sort of Minecraft modding so if I'm missing something obvious let me know. Thanks for the cool mod!